### PR TITLE
expand false on uix php file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,5 @@
  module.exports = function (grunt) {
-    
+
     // Project configuration.
     grunt.initConfig({
         pkg :   grunt.file.readJSON( '../package.json' ),
@@ -11,7 +11,7 @@
             main: {
                 files:[
                     {
-                        expand: true,
+                        expand: false,
                         cwd: './',
                         src: 'uix-bootstrap.php',
                         dest: '../'


### PR DESCRIPTION
ends up creating a directory `NAMESPACE-bootstrap.php` with the file inside it, instead of just copying the file
